### PR TITLE
support for the current v2 api of rpine pallete

### DIFF
--- a/.sizesnap.json
+++ b/.sizesnap.json
@@ -1,12 +1,12 @@
 {
   "./dist/rose-pine.css": {
-    "size": "1.41KB",
-    "brotli": "335B",
-    "gzip": "414B"
+    "size": "6.99KB",
+    "brotli": "1.06KB",
+    "gzip": "1.37KB"
   },
   "./dist/rose-pine.min.css": {
-    "size": "1.23KB",
-    "brotli": "330B",
-    "gzip": "400B"
+    "size": "6.35KB",
+    "brotli": "1.05KB",
+    "gzip": "1.35KB"
   }
 }

--- a/generate.mjs
+++ b/generate.mjs
@@ -1,4 +1,4 @@
-import {colorsByVariant} from '@rose-pine/palette'
+import {variants} from '@rose-pine/palette'
 import prettier from 'prettier'
 import fs from 'fs'
 import {paramCase} from 'param-case'
@@ -37,16 +37,25 @@ const purgeTemplate = (template) => {
 }
 
 function main() {
-  const variants = Object.keys(colorsByVariant)
-  variants.forEach((variant) => {
-    let path = `${STYLE_VARIABLE_PREFIX}${variant}-`
-    Object.keys(colorsByVariant[variant]).forEach((colorRole) => {
+  const _variants = Object.keys(variants)
+  _variants.forEach((variant) => {
+    const path = `${STYLE_VARIABLE_PREFIX}${variant}-`
+    Object.keys(variants[variant]).forEach((colorRole) => {
       const colorRoleText = paramCase(colorRole)
       const localPath = `${path}${colorRoleText}`
-      const color = colorsByVariant[variant][colorRole]
-      const cssVarName = pathToCSSVariable(localPath)
-      const cssVarString = varToStyleString(cssVarName, color)
-      styleSheet = appendToStylesheet(cssVarString)
+      const colorMap = variants[variant][colorRole]
+      Object.keys(colorMap).forEach((colorVal) => {
+        let colorPath = `${localPath}`
+        if (colorVal === 'alpha') {
+          return
+        }
+        if (colorVal !== 'hex') {
+          colorPath += `-${colorVal}`
+        }
+        const cssVarName = pathToCSSVariable(colorPath)
+        const cssVarString = varToStyleString(cssVarName, colorMap[colorVal])
+        styleSheet = appendToStylesheet(cssVarString)
+      })
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barelyhuman/rose-pine-css",
-  "version": "0.0.4-1",
+  "version": "0.0.4-2",
   "repository": "git@github.com:barelyhuman/rose-pine-css",
   "license": "MIT",
   "author": "Reaper <ahoy@barelyhuman.dev>",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "useTabs": false
   },
   "devDependencies": {
-    "@rose-pine/palette": "^1.1.0",
+    "@rose-pine/palette": "^2.0.0-6",
     "bundlesize": "^0.18.1",
     "csso": "^5.0.2",
     "json": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run clean; mkdir -p dist",
-    "build": "node generate.mjs",
+    "build": "node src/generate.mjs",
     "postbuild": "shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this.bundlesize=undefined; this.main=undefined; this['lint-staged']=undefined;\"",
     "clean": "rm -rf dist",
-    "dev": "nodemon generate.mjs",
+    "dev": "nodemon src/generate.mjs",
     "prepublishOnly": "npm run build",
     "size": "sizesnap",
     "test": "echo 'done'"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barelyhuman/rose-pine-css",
-  "version": "0.0.3",
+  "version": "0.0.4-0",
   "repository": "git@github.com:barelyhuman/rose-pine-css",
   "license": "MIT",
   "author": "Reaper <ahoy@barelyhuman.dev>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barelyhuman/rose-pine-css",
-  "version": "0.0.4-0",
+  "version": "0.0.4-1",
   "repository": "git@github.com:barelyhuman/rose-pine-css",
   "license": "MIT",
   "author": "Reaper <ahoy@barelyhuman.dev>",

--- a/src/extractor.mjs
+++ b/src/extractor.mjs
@@ -1,0 +1,20 @@
+import {paramCase} from 'param-case'
+
+export function colorExtractor(source, visitedPath = '') {
+  if (typeof source === 'string') {
+    return {color: source, path: visitedPath}
+  }
+
+  let colorMap = []
+
+  Object.keys(source).forEach((key) => {
+    let pathKey = paramCase(visitedPath)
+    if (key !== 'hex') {
+      pathKey += '-' + paramCase(key)
+    }
+    const val = colorExtractor(source[key], pathKey)
+    colorMap = colorMap.concat(val)
+  })
+
+  return colorMap
+}

--- a/src/generate.mjs
+++ b/src/generate.mjs
@@ -1,8 +1,8 @@
 import {variants} from '@rose-pine/palette'
 import prettier from 'prettier'
 import fs from 'fs'
-import {paramCase} from 'param-case'
 import {minify} from 'csso'
+import {colorExtractor} from './extractor.mjs'
 
 const TEMPLATE_KEY = '{{template}}'
 const STYLE_VARIABLE_PREFIX = 'rose-'
@@ -37,26 +37,12 @@ const purgeTemplate = (template) => {
 }
 
 function main() {
-  const _variants = Object.keys(variants)
+  const _variants = colorExtractor(variants)
   _variants.forEach((variant) => {
-    const path = `${STYLE_VARIABLE_PREFIX}${variant}-`
-    Object.keys(variants[variant]).forEach((colorRole) => {
-      const colorRoleText = paramCase(colorRole)
-      const localPath = `${path}${colorRoleText}`
-      const colorMap = variants[variant][colorRole]
-      Object.keys(colorMap).forEach((colorVal) => {
-        let colorPath = `${localPath}`
-        if (colorVal === 'alpha') {
-          return
-        }
-        if (colorVal !== 'hex') {
-          colorPath += `-${colorVal}`
-        }
-        const cssVarName = pathToCSSVariable(colorPath)
-        const cssVarString = varToStyleString(cssVarName, colorMap[colorVal])
-        styleSheet = appendToStylesheet(cssVarString)
-      })
-    })
+    const colorPath = `${STYLE_VARIABLE_PREFIX}${variant.path}`
+    const cssVarName = pathToCSSVariable(colorPath)
+    const cssVarString = varToStyleString(cssVarName, variant.color)
+    styleSheet = appendToStylesheet(cssVarString)
   })
 
   styleSheet = purgeTemplate(styleSheet)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@rose-pine/palette@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@rose-pine/palette/-/palette-1.1.0.tgz#a4ac964e2f1c2bd50730d1ea8ce7af162dc7f006"
-  integrity sha512-YVBMSQSipVxpzPsHGsSo5VSBHGi22O1k0FUChLHA/cGLseqn8xYJBCDRxFyxn51H47xkcdUuX/b5egcyKNkxDQ==
+"@rose-pine/palette@^2.0.0-6":
+  version "2.0.0-6"
+  resolved "https://registry.yarnpkg.com/@rose-pine/palette/-/palette-2.0.0-6.tgz#07a2cbc3f115367e11a10a9f304300986761ccc0"
+  integrity sha512-eI0eGecc7KeXEKkXSZzQZpf74HRUKWX8O3L7iP9vDVQ5xZVJQzBA+DBby4Jqsrfv0NcI+ZUA1GpOUZZFIzoLTw==
 
 ansi-regex@^2.0.0:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,6 +93,13 @@ brotli-size@0.1.0:
     duplexer "^0.1.1"
     iltorb "^2.4.3"
 
+brotli-size@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/brotli-size/-/brotli-size-4.0.0.tgz#a05ee3faad3c0e700a2f2da826ba6b4d76e69e5e"
+  integrity sha512-uA9fOtlTRC0iqKfzff1W34DXUA3GyVqbUaeo3Rw3d4gd1eavKVCETXrn3NzO74W+UVkG3UHu8WxUi+XvKI/huA==
+  dependencies:
+    duplexer "0.1.1"
+
 buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
@@ -117,7 +124,7 @@ bundlesize@^0.18.1:
     gzip-size "^4.0.0"
     prettycli "^1.4.3"
 
-bytes@^3.1.0:
+bytes@^3.1.0, bytes@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
   integrity sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==
@@ -252,6 +259,11 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+duplexer@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
+
 duplexer@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
@@ -348,6 +360,27 @@ glob@^7.0.0, glob@^7.1.4:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@~7.1.1:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globule@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/globule/-/globule-1.3.3.tgz#811919eeac1ab7344e905f2e3be80a13447973c2"
+  integrity sha512-mb1aYtDbIjTu4ShMB85m3UzjX9BVKe9WCzsnfMSZk+K5GpIbBOexgg4PPCt5eHDEG5/ZQAUX2Kct02zfiPLsKg==
+  dependencies:
+    glob "~7.1.1"
+    lodash "~4.17.10"
+    minimatch "~3.0.2"
 
 gzip-size@^4.0.0:
   version "4.1.0"
@@ -473,6 +506,11 @@ json@^11.0.0:
   resolved "https://registry.yarnpkg.com/json/-/json-11.0.0.tgz#2e84493134e2f42c131165aa22a124df38b3a3ee"
   integrity sha512-N/ITv3Yw9Za8cGxuQqSqrq6RHnlaHWZkAFavcfpH/R52522c26EbihMxnY7A1chxfXJ4d+cEFIsyTgfi9GihrA==
 
+lodash@~4.17.10:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -490,7 +528,7 @@ mimic-response@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -589,6 +627,11 @@ path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 pify@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
support for the current v2 api of rpine pallete

You can use the following to use it till rose-pine releases the v2 officially

CDN:
```
https://unpkg.com/@barelyhuman/rose-pine-css@next/rose-pine.css
```
or 

Node/Bundler:
```sh
npm i @barelyhuman/rose-pine-css@next
```

